### PR TITLE
rounds now get sorted by date, not by order in which they were entered

### DIFF
--- a/src/components/home/actions.js
+++ b/src/components/home/actions.js
@@ -4,6 +4,7 @@ import { db } from '../../services/firebase';
 const players = db.ref('players');
 
 export function getRounds(name){
+  
   return {
     type: LOAD_ROUNDS,
     payload: players.child(name).once('value').then(data => {
@@ -13,10 +14,28 @@ export function getRounds(name){
         round.key = key;
         return round;
       });
-    }
-    )
+    }).then(arr => arr.sort(function(a, b){
+      return a.date > b.date ? 1 : a.date < b.date ? -1 : 0;
+    }))
   };
+    
 }
+
+// this old get rounds function. did not sort by date, returned them in order entered
+// export function getRounds(name){
+//   return {
+//     type: LOAD_ROUNDS,
+//     payload: players.child(name).once('value').then(data => {
+//       const rounds = data.val();
+//       return Object.keys(rounds).map(key => {
+//         let round = rounds[key];
+//         round.key = key;
+//         return round;
+//       });
+//     }
+//     )
+//   };
+// }
 
 export function getScoreAvg(name, stat, handler){
   if(name === '') return;

--- a/src/components/viewRounds/actions.js
+++ b/src/components/viewRounds/actions.js
@@ -1,5 +1,5 @@
 import { db } from '../../services/firebase';
-import { DELETE_ROUND } from '../home/reducers';
+import { DELETE_ROUND, rounds } from '../home/reducers';
 
 const players = db.ref('players');
 
@@ -10,3 +10,4 @@ export function deleteRd(name, id){
       .then(() => id)
   };
 }
+


### PR DESCRIPTION
getRounds action in home/actions now sorts rounds by date they were played.  Before they came back in the order they were entered.